### PR TITLE
fix(windows): permit Windows UI to succeed by enabling mouse capture before disabling

### DIFF
--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use crossterm::{
-    event::DisableMouseCapture,
+    event::{DisableMouseCapture, EnableMouseCapture},
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
@@ -53,6 +53,10 @@ impl App {
             enable_raw_mode()?;
             execute!(
                 terminal.backend_mut(),
+                // NOTE: This is necessary due to upstream `crossterm` requiring that we "enable"
+                // mouse handling first, which saves some state that necessary for _disabling_
+                // mouse events.
+                EnableMouseCapture,
                 EnterAlternateScreen,
                 DisableMouseCapture
             )?;


### PR DESCRIPTION
Fixes #3.

---

This [upstream issue] for `crossterm` seems very relevant, but it's been
claimed to be fixed. Perhaps this fix simply hasn't yet been consumed in
`crossterm` 0.23.x, which we use?

[upstream issue]: https://github.com/crossterm-rs/crossterm/issues/377