### PR TITLE
Replace \t with space to workaround indentation issue

### DIFF
--- a/src/ui/context_viewer.rs
+++ b/src/ui/context_viewer.rs
@@ -115,7 +115,7 @@ impl ContextViewer {
                 line.iter()
                     .map(|(highlight_style, substring)| {
                         let fg = highlight_style.foreground;
-                        let substring_without_tab = substring.replace("\t", "    ");
+                        let substring_without_tab = substring.replace('\t', "    ");
                         Span::styled(
                             substring_without_tab,
                             Style::default().fg(Color::Rgb(fg.r, fg.g, fg.b)),

--- a/src/ui/context_viewer.rs
+++ b/src/ui/context_viewer.rs
@@ -115,7 +115,11 @@ impl ContextViewer {
                 line.iter()
                     .map(|(highlight_style, substring)| {
                         let fg = highlight_style.foreground;
-                        Span::styled(substring, Style::default().fg(Color::Rgb(fg.r, fg.g, fg.b)))
+                        let substring_without_tab = substring.replace("\t", "    ");
+                        Span::styled(
+                            substring_without_tab,
+                            Style::default().fg(Color::Rgb(fg.r, fg.g, fg.b)),
+                        )
                     })
                     .collect_vec()
             })


### PR DESCRIPTION
tui swallows \t https://github.com/fdehau/tui-rs/issues/98 , cause context view skew up indentation in some languages (e.g. Go). Thus make this workaround.