### PR TITLE
Add support for Sublime Text editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Runs [grep](https://crates.io/crates/grep) ([ripgrep's](https://github.com/Burnt
                               directories are skipped.
     --editor <EDITOR>         Text editor used to open selected match [possible values: vim,
                               neovim, nvim, nano, code, vscode, code-insiders, emacs,
-                              emacsclient, hx, helix]
+                              emacsclient, hx, helix, st, sublime_text]
 -g, --glob <GLOB>             Include files and directories for searching that match the given glob.
                               Multiple globs may be provided.
 -h, --help                    Print help information

--- a/src/ui/editor.rs
+++ b/src/ui/editor.rs
@@ -25,7 +25,7 @@ pub enum Editor {
     Emacsclient,
     Hx,
     Helix,
-    St,
+    Subl,
     SublimeText,
 }
 
@@ -92,7 +92,7 @@ impl EditorCommand {
             Editor::Emacs => "emacs".into(),
             Editor::Emacsclient => "emacsclient".into(),
             Editor::Hx | Editor::Helix => "hx".into(),
-            Editor::St | Editor::SublimeText => "subl".into(),
+            Editor::Subl | Editor::SublimeText => "subl".into(),
         }
     }
 
@@ -110,7 +110,7 @@ impl EditorCommand {
             Editor::Hx | Editor::Helix => {
                 Box::new([format!("{file_name}:{line_number}")].into_iter())
             }
-            Editor::St | Editor::SublimeText => {
+            Editor::Subl | Editor::SublimeText => {
                 Box::new([format!("{file_name}:{line_number}")].into_iter())
             }
         }

--- a/src/ui/editor.rs
+++ b/src/ui/editor.rs
@@ -25,6 +25,8 @@ pub enum Editor {
     Emacsclient,
     Hx,
     Helix,
+    St,
+    SublimeText,
 }
 
 impl Editor {
@@ -90,6 +92,7 @@ impl EditorCommand {
             Editor::Emacs => "emacs".into(),
             Editor::Emacsclient => "emacsclient".into(),
             Editor::Hx | Editor::Helix => "hx".into(),
+            Editor::St | Editor::SublimeText => "sublime_text".into(),
         }
     }
 
@@ -105,6 +108,9 @@ impl EditorCommand {
                 Box::new(["-nw".into(), format!("+{line_number}"), file_name.into()].into_iter())
             }
             Editor::Hx | Editor::Helix => {
+                Box::new([format!("{file_name}:{line_number}")].into_iter())
+            }
+            Editor::St | Editor::SublimeText => {
                 Box::new([format!("{file_name}:{line_number}")].into_iter())
             }
         }

--- a/src/ui/editor.rs
+++ b/src/ui/editor.rs
@@ -92,7 +92,7 @@ impl EditorCommand {
             Editor::Emacs => "emacs".into(),
             Editor::Emacsclient => "emacsclient".into(),
             Editor::Hx | Editor::Helix => "hx".into(),
-            Editor::St | Editor::SublimeText => "sublime_text".into(),
+            Editor::St | Editor::SublimeText => "subl".into(),
         }
     }
 


### PR DESCRIPTION
Greeting. I would like to add support for the [Sublime Text](https://www.sublimetext.com) editor.

I don't have the environment to test this but it seems to be quite simple by referencing https://github.com/konradsz/igrep/pull/28. 

But there is one thing that I don't understand and may need some help: how the `--editor` option `sublime_text` can be correlated to `Editor::SublimeText`? I don't see any special treatment for `code-insiders` v.s. `Editor::CodeInsiders`.

p.s. the command to open a file with Sublime Text is `sublime_text MY_FILE_PATH:LINE_NUM`.
