### PR TITLE
when editor is helix, use `helix` instead of `hx`

### DIFF
--- a/src/ui/editor.rs
+++ b/src/ui/editor.rs
@@ -87,7 +87,8 @@ impl EditorCommand {
             Editor::CodeInsiders => "code-insiders".into(),
             Editor::Emacs => "emacs".into(),
             Editor::Emacsclient => "emacsclient".into(),
-            Editor::Hx | Editor::Helix => "hx".into(),
+            Editor::Hx => "hx".into(),
+            Editor::Helix => "helix".into(),
             Editor::Subl | Editor::SublimeText => "subl".into(),
         }
     }

--- a/src/ui/editor.rs
+++ b/src/ui/editor.rs
@@ -189,7 +189,7 @@ mod tests {
     #[test_case(Editor::Emacs => format!("emacs -nw +{LINE_NUMBER} {FILE_NAME}"); "emacs command")]
     #[test_case(Editor::Emacsclient => format!("emacsclient -nw +{LINE_NUMBER} {FILE_NAME}"); "emacsclient command")]
     #[test_case(Editor::Hx => format!("hx {FILE_NAME}:{LINE_NUMBER}"); "hx command")]
-    #[test_case(Editor::Helix => format!("hx {FILE_NAME}:{LINE_NUMBER}"); "helix command")]
+    #[test_case(Editor::Helix => format!("helix {FILE_NAME}:{LINE_NUMBER}"); "helix command")]
     fn editor_command(editor: Editor) -> String {
         EditorCommand::new(editor, FILE_NAME, LINE_NUMBER).to_string()
     }


### PR DESCRIPTION
When the editor is `helix`, this uses a `helix` binary instead of `hx`. It doesn't affect the behaviour when the editor is set to `hx`.

This is required for Arch Linux, which doesn't ship an `hx` binary.