### PR TITLE
prefer $VISUAL over $EDITOR

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -11,6 +11,7 @@ use std::{
 pub const IGREP_EDITOR_ENV: &str = "IGREP_EDITOR";
 pub const EDITOR_ENV: &str = "EDITOR";
 pub const RIPGREP_CONFIG_PATH_ENV: &str = "RIPGREP_CONFIG_PATH";
+pub const VISUAL_ENV: &str = "VISUAL";
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]

--- a/src/ui/editor.rs
+++ b/src/ui/editor.rs
@@ -50,7 +50,7 @@ impl Editor {
         };
 
         editor_cli
-            .map(|editor_cli| Ok(editor_cli))
+            .map(Ok)
             .or_else(|| read_from_env(IGREP_EDITOR_ENV))
             .or_else(|| read_from_env(VISUAL_ENV))
             .or_else(|| read_from_env(EDITOR_ENV))

--- a/src/ui/editor.rs
+++ b/src/ui/editor.rs
@@ -1,4 +1,4 @@
-use crate::args::{EDITOR_ENV, IGREP_EDITOR_ENV};
+use crate::args::{EDITOR_ENV, IGREP_EDITOR_ENV, VISUAL_ENV};
 use anyhow::{anyhow, Result};
 use clap::ArgEnum;
 use itertools::Itertools;
@@ -48,6 +48,10 @@ impl Editor {
             let value = Editor::extract_editor_name(&value);
             Editor::from_str(&value, false)
                 .map_err(|error| add_error_context(error, value, IGREP_EDITOR_ENV))
+        } else if let Ok(value) = std::env::var(VISUAL_ENV) {
+            let value = Editor::extract_editor_name(&value);
+            Editor::from_str(&value, false)
+                .map_err(|error| add_error_context(error, value, VISUAL_ENV))
         } else if let Ok(value) = std::env::var(EDITOR_ENV) {
             let value = Editor::extract_editor_name(&value);
             Editor::from_str(&value, false)
@@ -156,6 +160,7 @@ mod tests {
     ) -> Result<Editor> {
         let _guard = SERIAL_TEST.lock().unwrap();
         std::env::remove_var(IGREP_EDITOR_ENV);
+        std::env::remove_var(VISUAL_ENV);
         std::env::remove_var(EDITOR_ENV);
 
         let opt = if let Some(cli_option) = cli_option {

--- a/src/ui/editor.rs
+++ b/src/ui/editor.rs
@@ -140,18 +140,20 @@ mod tests {
         static ref SERIAL_TEST: std::sync::Mutex<()> = Default::default();
     }
 
-    #[test_case(Some("nano"), Some("vim"), Some("neovim") => matches Ok(Editor::Nano); "cli")]
-    #[test_case(None, Some("nano"), Some("neovim") => matches Ok(Editor::Nano); "igrep env")]
-    #[test_case(None, None, Some("nano") => matches Ok(Editor::Nano); "editor env")]
-    #[test_case(Some("unsupported-editor"), None, None => matches Err(_); "unsupported cli")]
-    #[test_case(None, Some("unsupported-editor"), None => matches Err(_); "unsupported igrep env")]
-    #[test_case(None, None, Some("unsupported-editor") => matches Err(_); "unsupported editor env")]
-    #[test_case(None, None, None => matches Ok(Editor::Vim); "default editor")]
-    #[test_case(None, Some("/usr/bin/nano"), None => matches Ok(Editor::Nano); "igrep env path")]
-    #[test_case(None, None, Some("/usr/bin/nano") => matches Ok(Editor::Nano); "editor env path")]
+    #[test_case(Some("nano"), Some("vim"), None, Some("neovim") => matches Ok(Editor::Nano); "cli")]
+    #[test_case(None, Some("nano"), None, Some("neovim") => matches Ok(Editor::Nano); "igrep env")]
+    #[test_case(None, None, Some("nano"), Some("helix") => matches Ok(Editor::Nano); "visual env")]
+    #[test_case(None, None, None, Some("nano") => matches Ok(Editor::Nano); "editor env")]
+    #[test_case(Some("unsupported-editor"), None, None, None => matches Err(_); "unsupported cli")]
+    #[test_case(None, Some("unsupported-editor"), None, None => matches Err(_); "unsupported igrep env")]
+    #[test_case(None, None, None, Some("unsupported-editor") => matches Err(_); "unsupported editor env")]
+    #[test_case(None, None, None, None => matches Ok(Editor::Vim); "default editor")]
+    #[test_case(None, Some("/usr/bin/nano"), None, None => matches Ok(Editor::Nano); "igrep env path")]
+    #[test_case(None, None, None, Some("/usr/bin/nano") => matches Ok(Editor::Nano); "editor env path")]
     fn editor_options_precedence(
         cli_option: Option<&str>,
         igrep_editor_env: Option<&str>,
+        visual_env: Option<&str>,
         editor_env: Option<&str>,
     ) -> Result<Editor> {
         let _guard = SERIAL_TEST.lock().unwrap();
@@ -167,6 +169,10 @@ mod tests {
 
         if let Some(igrep_editor_env) = igrep_editor_env {
             std::env::set_var(IGREP_EDITOR_ENV, igrep_editor_env);
+        }
+
+        if let Some(visual_env) = visual_env {
+            std::env::set_var(VISUAL_ENV, visual_env);
         }
 
         if let Some(editor_env) = editor_env {


### PR DESCRIPTION
This prefers the $VISUAL environment variable over $EDITOR, which mirrors the behaviour of other applications.

This is not yet reflected in the test, specifically `crate::ui::editor::tests::editor_options_precedence`, because I don't know how the `#[test_case(…)]` macro works.