### PR TITLE
Update installation instructions for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ brew install igrep
 scoop bucket add igrep https://github.com/konradsz/igrep.git
 scoop install igrep
 ```
-### AUR
+### Arch Linux
 ```
-paru -S igrep
+pacman -S igrep
 ```
 ### Build from source
 Build and install from source using Rust toolchain by running: `cargo install igrep`.


### PR DESCRIPTION
I have been using `igrep` extensively for content search for the past couple of weeks and I really enjoy the simplicity. So I moved it to the Arch Linux community repository as an official binary package which means more users will be able to install it easily.

- https://archlinux.org/packages/community/x86_64/igrep/

Also it can now be installed via [pacman](https://wiki.archlinux.org/title/Pacman).

```
  __        ___
 / o\      /o o\
|   <      |   |
 \__/      |,,,|
```

Cheers!
