### PR TITLE
improve search pattern updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ NOTE: `ig` respects `ripgrep`'s [configuration file](https://github.com/BurntSus
 | `s`                      | Toggle horizontal context viewer       |
 | `+`                      | Increase context viewer size           |
 | `-`                      | Decrease context viewer size           |
-| `F5`                     | Open search pattern popup              |
+| `F5`, `/`                | Open search pattern popup              |
 <!-- keybindings end -->
 
 ## Supported text editors

--- a/src/app.rs
+++ b/src/app.rs
@@ -211,6 +211,18 @@ impl Application for App {
         self.search_popup.remove_char();
     }
 
+    fn on_char_deleted(&mut self) {
+        self.search_popup.delete_char();
+    }
+
+    fn on_char_left(&mut self) {
+        self.search_popup.left();
+    }
+
+    fn on_char_right(&mut self) {
+        self.search_popup.right();
+    }
+
     fn on_toggle_keymap(&mut self) {
         self.keymap_popup.toggle();
     }
@@ -253,6 +265,9 @@ pub trait Application {
     fn on_toggle_popup(&mut self);
     fn on_char_inserted(&mut self, c: char);
     fn on_char_removed(&mut self);
+    fn on_char_deleted(&mut self);
+    fn on_char_left(&mut self);
+    fn on_char_right(&mut self);
     fn on_toggle_keymap(&mut self);
     fn on_keymap_up(&mut self);
     fn on_keymap_down(&mut self);

--- a/src/app.rs
+++ b/src/app.rs
@@ -216,11 +216,11 @@ impl Application for App {
     }
 
     fn on_char_left(&mut self) {
-        self.search_popup.left();
+        self.search_popup.move_cursor_left();
     }
 
     fn on_char_right(&mut self) {
-        self.search_popup.right();
+        self.search_popup.move_cursor_right();
     }
 
     fn on_toggle_keymap(&mut self) {

--- a/src/ui/input_handler.rs
+++ b/src/ui/input_handler.rs
@@ -110,6 +110,18 @@ impl InputHandler {
                 ..
             } => app.on_char_removed(),
             KeyEvent {
+                code: KeyCode::Delete,
+                ..
+            } => app.on_char_deleted(),
+            KeyEvent {
+                code: KeyCode::Left,
+                ..
+            } => app.on_char_left(),
+            KeyEvent {
+                code: KeyCode::Right,
+                ..
+            } => app.on_char_right(),
+            KeyEvent {
                 code: KeyCode::Enter,
                 ..
             } => {
@@ -202,6 +214,10 @@ impl InputHandler {
             "q" => consume_buffer_and_execute(&mut self.input_buffer, &mut || app.on_exit()),
             "?" => {
                 consume_buffer_and_execute(&mut self.input_buffer, &mut || app.on_toggle_keymap())
+            }
+            "/" => {
+                self.input_mode = InputMode::TextInsertion;
+                consume_buffer_and_execute(&mut self.input_buffer, &mut || app.on_toggle_popup())
             }
             "g" => self.input_state = InputState::Incomplete("g…".into()),
             "d" => self.input_state = InputState::Incomplete("d…".into()),
@@ -385,11 +401,12 @@ mod tests {
         handle_key(KeyCode::Enter, &mut app_mock);
     }
 
-    #[test]
-    fn search() {
+    #[test_case(KeyCode::F(5))]
+    #[test_case(KeyCode::Char('/'))]
+    fn search(key_code: KeyCode) {
         let mut app_mock = MockApplication::default();
         app_mock.expect_on_toggle_popup().once().return_const(());
-        handle_key(KeyCode::F(5), &mut app_mock);
+        handle_key(key_code, &mut app_mock);
     }
 
     #[test_case(KeyCode::F(1))]

--- a/src/ui/search_popup.rs
+++ b/src/ui/search_popup.rs
@@ -11,7 +11,7 @@ use super::theme::Theme;
 pub struct SearchPopup {
     visible: bool,
     pattern: String,
-    position: usize,
+    cursor_position: usize,
 }
 
 impl SearchPopup {
@@ -21,7 +21,7 @@ impl SearchPopup {
 
     pub fn set_pattern(&mut self, pattern: String) {
         self.pattern = pattern;
-        self.position = self.pattern.len();
+        self.cursor_position = self.pattern.len();
     }
 
     pub fn get_pattern(&self) -> String {
@@ -29,32 +29,32 @@ impl SearchPopup {
     }
 
     pub fn insert_char(&mut self, c: char) {
-        self.pattern.insert(self.position, c);
-        self.right();
+        self.pattern.insert(self.cursor_position, c);
+        self.move_cursor_right();
     }
 
     pub fn remove_char(&mut self) {
-        self.left();
+        self.move_cursor_left();
         if !self.pattern.is_empty() {
-            self.pattern.remove(self.position);
+            self.pattern.remove(self.cursor_position);
         }
     }
 
     pub fn delete_char(&mut self) {
-        if self.position < self.pattern.len() {
-            self.pattern.remove(self.position);
+        if self.cursor_position < self.pattern.len() {
+            self.pattern.remove(self.cursor_position);
         }
     }
 
-    pub fn left(&mut self) {
-        if self.position > 0 {
-            self.position -= 1;
+    pub fn move_cursor_left(&mut self) {
+        if self.cursor_position > 0 {
+            self.cursor_position -= 1;
         }
     }
 
-    pub fn right(&mut self) {
-        if self.position < self.pattern.len() {
-            self.position += 1;
+    pub fn move_cursor_right(&mut self) {
+        if self.cursor_position < self.pattern.len() {
+            self.cursor_position += 1;
         }
     }
 
@@ -92,7 +92,7 @@ impl SearchPopup {
         frame.render_widget(pattern_text, text_area);
         frame.set_cursor(
             std::cmp::min(
-                text_area.x + self.position as u16,
+                text_area.x + self.cursor_position as u16,
                 text_area.x + text_area.width - 4,
             ),
             text_area.y,

--- a/src/ui/search_popup.rs
+++ b/src/ui/search_popup.rs
@@ -11,6 +11,7 @@ use super::theme::Theme;
 pub struct SearchPopup {
     visible: bool,
     pattern: String,
+    position: usize,
 }
 
 impl SearchPopup {
@@ -20,6 +21,7 @@ impl SearchPopup {
 
     pub fn set_pattern(&mut self, pattern: String) {
         self.pattern = pattern;
+        self.position = self.pattern.len();
     }
 
     pub fn get_pattern(&self) -> String {
@@ -27,11 +29,33 @@ impl SearchPopup {
     }
 
     pub fn insert_char(&mut self, c: char) {
-        self.pattern.push(c);
+        self.pattern.insert(self.position, c);
+        self.right();
     }
 
     pub fn remove_char(&mut self) {
-        self.pattern.pop();
+        self.left();
+        if !self.pattern.is_empty() {
+            self.pattern.remove(self.position);
+        }
+    }
+
+    pub fn delete_char(&mut self) {
+        if self.position < self.pattern.len() {
+            self.pattern.remove(self.position);
+        }
+    }
+
+    pub fn left(&mut self) {
+        if self.position > 0 {
+            self.position -= 1;
+        }
+    }
+
+    pub fn right(&mut self) {
+        if self.position < self.pattern.len() {
+            self.position += 1;
+        }
     }
 
     pub fn draw(&self, frame: &mut Frame, theme: &dyn Theme) {
@@ -68,7 +92,7 @@ impl SearchPopup {
         frame.render_widget(pattern_text, text_area);
         frame.set_cursor(
             std::cmp::min(
-                text_area.x + pattern.len() as u16,
+                text_area.x + self.position as u16,
                 text_area.x + text_area.width - 4,
             ),
             text_area.y,


### PR DESCRIPTION
Thanks for this great tool.

Instead of only changing the search pattern from the back, the arrow keys can be used to navigate and change the search pattern at arbitrary places.

also adds `/` as hotkey, like in vim.