### PR TITLE
allow to Sort results.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Runs [grep](https://crates.io/crates/grep) ([ripgrep's](https://github.com/Burnt
     --type-list                 Show all supported file types and their corresponding globs.
 -V, --version                   Print version information.
 -w, --word-regexp               Only show matches surrounded by word boundaries
+    --sort <SORT_BY>            Sort results by [path, modified, accessed, created], see ripgrep for details
+    --sortr <SORT_BY_REVERSE>   Sort results reverse by [path, modified, accessed, created], see ripgrep for details
 ```
 NOTE: `ig` respects `ripgrep`'s [configuration file](https://github.com/BurntSushi/ripgrep/blob/master/GUIDE.md#configuration-file) if `RIPGREP_CONFIG_PATH` environment variable is set and reads all supported options from it.
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ NOTE: `ig` respects `ripgrep`'s [configuration file](https://github.com/BurntSus
 | `+`                      | Increase context viewer size           |
 | `-`                      | Decrease context viewer size           |
 | `F5`, `/`                | Open search pattern popup              |
+| `n`                      | Sort search results by name            |
+| `m`                      | Sort search results by mtime           |
+| `c`                      | Sort search results by ctime           |
+| `a`                      | Sort search results by atime           |
 <!-- keybindings end -->
 
 ## Supported text editors

--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ NOTE: `ig` respects `ripgrep`'s [configuration file](https://github.com/BurntSus
 | `-`                      | Decrease context viewer size           |
 | `F5`, `/`                | Open search pattern popup              |
 | `n`                      | Sort search results by name            |
-| `m`                      | Sort search results by mtime           |
-| `c`                      | Sort search results by ctime           |
-| `a`                      | Sort search results by atime           |
+| `m`                      | Sort search results by time modified   |
+| `c`                      | Sort search results by time created    |
+| `a`                      | Sort search results by time accessed   |
 <!-- keybindings end -->
 
 ## Supported text editors

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,6 @@
 use crate::{
     editor::EditorCommand,
-    ig::{Ig, SearchConfig},
+    ig::{Ig, SearchConfig, SortKey},
     ui::{
         bottom_bar, context_viewer::ContextViewer, input_handler::InputHandler,
         keymap_popup::KeymapPopup, result_list::ResultList, search_popup::SearchPopup,
@@ -184,10 +184,10 @@ impl Application for App {
 
     fn on_toggle_sort_name(&mut self) {
         if self.search_config.sort_by.is_some() {
-            self.search_config.sort_by_reversed = Some("path".to_string());
+            self.search_config.sort_by_reversed = Some(SortKey::Path);
             self.search_config.sort_by = None;
         } else {
-            self.search_config.sort_by = Some("path".to_string());
+            self.search_config.sort_by = Some(SortKey::Path);
             self.search_config.sort_by_reversed = None;
         }
         self.ig
@@ -196,10 +196,10 @@ impl Application for App {
 
     fn on_toggle_sort_mtime(&mut self) {
         if self.search_config.sort_by.is_some() {
-            self.search_config.sort_by_reversed = Some("modified".to_string());
+            self.search_config.sort_by_reversed = Some(SortKey::Modified);
             self.search_config.sort_by = None;
         } else {
-            self.search_config.sort_by = Some("modified".to_string());
+            self.search_config.sort_by = Some(SortKey::Modified);
             self.search_config.sort_by_reversed = None;
         }
         self.ig
@@ -208,10 +208,10 @@ impl Application for App {
 
     fn on_toggle_sort_ctime(&mut self) {
         if self.search_config.sort_by.is_some() {
-            self.search_config.sort_by_reversed = Some("created".to_string());
+            self.search_config.sort_by_reversed = Some(SortKey::Created);
             self.search_config.sort_by = None;
         } else {
-            self.search_config.sort_by = Some("created".to_string());
+            self.search_config.sort_by = Some(SortKey::Created);
             self.search_config.sort_by_reversed = None;
         }
         self.ig
@@ -220,10 +220,10 @@ impl Application for App {
 
     fn on_toggle_sort_atime(&mut self) {
         if self.search_config.sort_by.is_some() {
-            self.search_config.sort_by_reversed = Some("accessed".to_string());
+            self.search_config.sort_by_reversed = Some(SortKey::Accessed);
             self.search_config.sort_by = None;
         } else {
-            self.search_config.sort_by = Some("accessed".to_string());
+            self.search_config.sort_by = Some(SortKey::Accessed);
             self.search_config.sort_by_reversed = None;
         }
         self.ig

--- a/src/app.rs
+++ b/src/app.rs
@@ -183,8 +183,7 @@ impl Application for App {
     }
 
     fn on_toggle_sort_name(&mut self) {
-        if self.search_config.sort_by.is_some()
-        {
+        if self.search_config.sort_by.is_some() {
             self.search_config.sort_by_reversed = Some("path".to_string());
             self.search_config.sort_by = None;
         } else {
@@ -196,8 +195,7 @@ impl Application for App {
     }
 
     fn on_toggle_sort_mtime(&mut self) {
-        if self.search_config.sort_by.is_some()
-        {
+        if self.search_config.sort_by.is_some() {
             self.search_config.sort_by_reversed = Some("modified".to_string());
             self.search_config.sort_by = None;
         } else {
@@ -209,8 +207,7 @@ impl Application for App {
     }
 
     fn on_toggle_sort_ctime(&mut self) {
-        if self.search_config.sort_by.is_some()
-        {
+        if self.search_config.sort_by.is_some() {
             self.search_config.sort_by_reversed = Some("created".to_string());
             self.search_config.sort_by = None;
         } else {
@@ -222,8 +219,7 @@ impl Application for App {
     }
 
     fn on_toggle_sort_atime(&mut self) {
-        if self.search_config.sort_by.is_some()
-        {
+        if self.search_config.sort_by.is_some() {
             self.search_config.sort_by_reversed = Some("accessed".to_string());
             self.search_config.sort_by = None;
         } else {

--- a/src/app.rs
+++ b/src/app.rs
@@ -182,6 +182,58 @@ impl Application for App {
         self.context_viewer.decrease_size();
     }
 
+    fn on_toggle_sort_name(&mut self) {
+        if self.search_config.sort_by.is_some()
+        {
+            self.search_config.sort_by_reversed = Some("path".to_string());
+            self.search_config.sort_by = None;
+        } else {
+            self.search_config.sort_by = Some("path".to_string());
+            self.search_config.sort_by_reversed = None;
+        }
+        self.ig
+            .search(self.search_config.clone(), &mut self.result_list);
+    }
+
+    fn on_toggle_sort_mtime(&mut self) {
+        if self.search_config.sort_by.is_some()
+        {
+            self.search_config.sort_by_reversed = Some("modified".to_string());
+            self.search_config.sort_by = None;
+        } else {
+            self.search_config.sort_by = Some("modified".to_string());
+            self.search_config.sort_by_reversed = None;
+        }
+        self.ig
+            .search(self.search_config.clone(), &mut self.result_list);
+    }
+
+    fn on_toggle_sort_ctime(&mut self) {
+        if self.search_config.sort_by.is_some()
+        {
+            self.search_config.sort_by_reversed = Some("created".to_string());
+            self.search_config.sort_by = None;
+        } else {
+            self.search_config.sort_by = Some("created".to_string());
+            self.search_config.sort_by_reversed = None;
+        }
+        self.ig
+            .search(self.search_config.clone(), &mut self.result_list);
+    }
+
+    fn on_toggle_sort_atime(&mut self) {
+        if self.search_config.sort_by.is_some()
+        {
+            self.search_config.sort_by_reversed = Some("accessed".to_string());
+            self.search_config.sort_by = None;
+        } else {
+            self.search_config.sort_by = Some("accessed".to_string());
+            self.search_config.sort_by_reversed = None;
+        }
+        self.ig
+            .search(self.search_config.clone(), &mut self.result_list);
+    }
+
     fn on_open_file(&mut self) {
         self.ig.open_file();
     }
@@ -259,6 +311,10 @@ pub trait Application {
     fn on_toggle_context_viewer_horizontal(&mut self);
     fn on_increase_context_viewer_size(&mut self);
     fn on_decrease_context_viewer_size(&mut self);
+    fn on_toggle_sort_name(&mut self);
+    fn on_toggle_sort_mtime(&mut self);
+    fn on_toggle_sort_ctime(&mut self);
+    fn on_toggle_sort_atime(&mut self);
     fn on_open_file(&mut self);
     fn on_search(&mut self);
     fn on_exit(&mut self);

--- a/src/args.rs
+++ b/src/args.rs
@@ -65,6 +65,12 @@ pub struct Args {
     /// Context viewer position at startup
     #[clap(long, value_enum, default_value_t = ContextViewerPosition::None)]
     pub context_viewer: ContextViewerPosition,
+    /// Sort results by [path, modified, accessed, created], see ripgrep for details
+    #[clap(long = "sort")]
+    pub sort_by: Option<String>,
+    /// Sort results reverse by [path, modified, accessed, created], see ripgrep for details
+    #[clap(long = "sortr")]
+    pub sort_by_reverse: Option<String>,
 }
 
 #[derive(Parser, Debug)]

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,7 +1,7 @@
 use crate::{
     editor::Editor,
-    ui::{context_viewer::ContextViewerPosition, theme::ThemeVariant},
     ig::search_config::SortKey,
+    ui::{context_viewer::ContextViewerPosition, theme::ThemeVariant},
 };
 use clap::{CommandFactory, Parser};
 use std::{

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,6 +1,7 @@
 use crate::{
     editor::Editor,
     ui::{context_viewer::ContextViewerPosition, theme::ThemeVariant},
+    ig::search_config::SortKey,
 };
 use clap::{CommandFactory, Parser};
 use std::{
@@ -65,12 +66,12 @@ pub struct Args {
     /// Context viewer position at startup
     #[clap(long, value_enum, default_value_t = ContextViewerPosition::None)]
     pub context_viewer: ContextViewerPosition,
-    /// Sort results by [path, modified, accessed, created], see ripgrep for details
+    /// Sort results, see ripgrep for details
     #[clap(long = "sort")]
-    pub sort_by: Option<String>,
-    /// Sort results reverse by [path, modified, accessed, created], see ripgrep for details
+    pub sort_by: Option<SortKey>,
+    /// Sort results reverse, see ripgrep for details
     #[clap(long = "sortr")]
-    pub sort_by_reverse: Option<String>,
+    pub sort_by_reverse: Option<SortKey>,
 }
 
 #[derive(Parser, Debug)]

--- a/src/ig.rs
+++ b/src/ig.rs
@@ -1,6 +1,6 @@
 pub mod file_entry;
 pub mod grep_match;
-mod search_config;
+pub mod search_config;
 mod searcher;
 mod sink;
 
@@ -10,6 +10,7 @@ use std::sync::mpsc;
 use crate::editor::EditorCommand;
 use crate::ui::result_list::ResultList;
 pub use search_config::SearchConfig;
+pub use search_config::SortKey;
 use searcher::Event;
 
 use self::file_entry::FileEntry;

--- a/src/ig/search_config.rs
+++ b/src/ig/search_config.rs
@@ -1,10 +1,10 @@
 use anyhow::Result;
+use clap::ValueEnum;
 use ignore::{
     overrides::{Override, OverrideBuilder},
     types::{Types, TypesBuilder},
 };
 use std::path::PathBuf;
-use clap::ValueEnum;
 use strum::Display;
 
 #[derive(Clone, ValueEnum, Display, Debug, PartialEq)]

--- a/src/ig/search_config.rs
+++ b/src/ig/search_config.rs
@@ -87,7 +87,6 @@ impl SearchConfig {
         Ok(self)
     }
 
-
     pub fn search_hidden(mut self, search_hidden: bool) -> Self {
         self.search_hidden = search_hidden;
         self

--- a/src/ig/search_config.rs
+++ b/src/ig/search_config.rs
@@ -16,6 +16,8 @@ pub struct SearchConfig {
     pub search_hidden: bool,
     pub follow_links: bool,
     pub word_regexp: bool,
+    pub sort_by: Option<String>,
+    pub sort_by_reversed: Option<String>,
 }
 
 impl SearchConfig {
@@ -34,6 +36,8 @@ impl SearchConfig {
             search_hidden: false,
             follow_links: false,
             word_regexp: false,
+            sort_by: None,
+            sort_by_reversed: None,
         })
     }
 
@@ -72,6 +76,17 @@ impl SearchConfig {
         self.types = builder.build()?;
         Ok(self)
     }
+
+    pub fn sort_by(
+        mut self,
+        sort_by: Option<String>,
+        sort_by_reversed: Option<String>,
+    ) -> Result<Self> {
+        self.sort_by = sort_by;
+        self.sort_by_reversed = sort_by_reversed;
+        Ok(self)
+    }
+
 
     pub fn search_hidden(mut self, search_hidden: bool) -> Self {
         self.search_hidden = search_hidden;

--- a/src/ig/search_config.rs
+++ b/src/ig/search_config.rs
@@ -4,6 +4,16 @@ use ignore::{
     types::{Types, TypesBuilder},
 };
 use std::path::PathBuf;
+use clap::ValueEnum;
+use strum::Display;
+
+#[derive(Clone, ValueEnum, Display, Debug, PartialEq)]
+pub enum SortKey {
+    Path,
+    Modified,
+    Created,
+    Accessed,
+}
 
 #[derive(Clone)]
 pub struct SearchConfig {
@@ -16,8 +26,8 @@ pub struct SearchConfig {
     pub search_hidden: bool,
     pub follow_links: bool,
     pub word_regexp: bool,
-    pub sort_by: Option<String>,
-    pub sort_by_reversed: Option<String>,
+    pub sort_by: Option<SortKey>,
+    pub sort_by_reversed: Option<SortKey>,
 }
 
 impl SearchConfig {
@@ -79,8 +89,8 @@ impl SearchConfig {
 
     pub fn sort_by(
         mut self,
-        sort_by: Option<String>,
-        sort_by_reversed: Option<String>,
+        sort_by: Option<SortKey>,
+        sort_by_reversed: Option<SortKey>,
     ) -> Result<Self> {
         self.sort_by = sort_by;
         self.sort_by_reversed = sort_by_reversed;

--- a/src/ig/searcher.rs
+++ b/src/ig/searcher.rs
@@ -1,9 +1,9 @@
 use super::{file_entry::FileEntry, sink::MatchesSink, SearchConfig};
+use crate::ig::SortKey;
 use grep::{
     matcher::LineTerminator,
     regex::RegexMatcherBuilder,
     searcher::{BinaryDetection, SearcherBuilder},
-    //    flags::lowargs::{SortMode,},
 };
 use ignore::WalkBuilder;
 use std::cmp::Ordering;
@@ -14,6 +14,7 @@ pub enum Event {
     SearchingFinished,
     Error,
 }
+
 
 pub fn search(config: SearchConfig, tx: mpsc::Sender<Event>) {
     std::thread::spawn(move || {
@@ -102,8 +103,8 @@ fn run(path: &Path, config: SearchConfig, tx: mpsc::Sender<Event>) {
         let mut walk_sorted = walker;
         let reversed = config.sort_by_reversed.is_some();
 
-        if config.sort_by == Some("path".to_string())
-            || config.sort_by_reversed == Some("path".to_string())
+        if config.sort_by == Some(SortKey::Path)
+            || config.sort_by_reversed == Some(SortKey::Path)
         {
             walk_sorted =
                 walk_sorted.sort_by_file_name(
@@ -115,8 +116,8 @@ fn run(path: &Path, config: SearchConfig, tx: mpsc::Sender<Event>) {
                         }
                     },
                 );
-        } else if config.sort_by == Some("modified".to_string())
-            || config.sort_by_reversed == Some("modified".to_string())
+        } else if config.sort_by == Some(SortKey::Modified)
+            || config.sort_by_reversed == Some(SortKey::Modified)
         {
             let compare_modified = move |a: &Path, b: &Path| -> Ordering {
                 let ma = a.metadata().expect("cannot get metadata from file");
@@ -133,8 +134,8 @@ fn run(path: &Path, config: SearchConfig, tx: mpsc::Sender<Event>) {
             };
 
             walk_sorted = walk_sorted.sort_by_file_path(compare_modified);
-        } else if config.sort_by == Some("created".to_string())
-            || config.sort_by_reversed == Some("created".to_string())
+        } else if config.sort_by == Some(SortKey::Created)
+            || config.sort_by_reversed == Some(SortKey::Created)
         {
             let compare_created = move |a: &Path, b: &Path| -> Ordering {
                 let ma = a.metadata().expect("cannot get metadata from file");
@@ -151,8 +152,8 @@ fn run(path: &Path, config: SearchConfig, tx: mpsc::Sender<Event>) {
             };
 
             walk_sorted = walk_sorted.sort_by_file_path(compare_created);
-        } else if config.sort_by == Some("accessed".to_string())
-            || config.sort_by_reversed == Some("accessed".to_string())
+        } else if config.sort_by == Some(SortKey::Accessed)
+            || config.sort_by_reversed == Some(SortKey::Accessed)
         {
             let compare_accessed = move |a: &Path, b: &Path| -> Ordering {
                 let ma = a.metadata().expect("cannot get metadata from file");

--- a/src/ig/searcher.rs
+++ b/src/ig/searcher.rs
@@ -116,50 +116,69 @@ fn run(path: &Path, config: SearchConfig, tx: mpsc::Sender<Event>) {
         }
         else if config.sort_by == Some("modified".to_string()) || config.sort_by_reversed == Some("modified".to_string())
         {
-            fn compare_modified (a: &Path, b: &Path) -> Ordering {
+            let compare_modified  = move |a: &Path, b: &Path| -> Ordering {
                 let ma = a.metadata().expect("cannot get metadata from file");
                 let mb = b.metadata().expect("cannot get metadata from file");
 
                 let ta = ma.modified().expect("cannot get time of file");
                 let tb = mb.modified().expect("cannot get time of file");
 
-                ta.cmp(&tb)
-            }
+                if !reversed
+                {
+                    ta.cmp(&tb)
+                } else {
+                    tb.cmp(&ta)
+                }
+            };
+
             walk_sorted = walk_sorted
                 .sort_by_file_path(move |a,b| { compare_modified(a,b) } );
+            
         }
         else if config.sort_by == Some("created".to_string()) || config.sort_by_reversed == Some("created".to_string())
         {
-            fn compare_created (a: &Path, b: &Path) -> Ordering {
+            let compare_created = move |a: &Path, b: &Path| -> Ordering {
                 let ma = a.metadata().expect("cannot get metadata from file");
                 let mb = b.metadata().expect("cannot get metadata from file");
 
                 let ta = ma.created().expect("cannot get time of file");
                 let tb = mb.created().expect("cannot get time of file");
 
-                ta.cmp(&tb)
-            }
+                if !reversed
+                {
+                    ta.cmp(&tb)
+                } else {
+                    tb.cmp(&ta)
+                }
+            };
+
             walk_sorted = walk_sorted
                 .sort_by_file_path(move |a,b| { compare_created(a,b) } );
         }
         else if config.sort_by == Some("accessed".to_string()) || config.sort_by_reversed == Some("accessed".to_string())
         {
-            fn compare_accessed (a: &Path, b: &Path) -> Ordering {
+            let compare_accessed = move |a: &Path, b: &Path| -> Ordering {
                 let ma = a.metadata().expect("cannot get metadata from file");
                 let mb = b.metadata().expect("cannot get metadata from file");
 
                 let ta = ma.accessed().expect("cannot get time of file");
                 let tb = mb.accessed().expect("cannot get time of file");
 
-                ta.cmp(&tb)
-            }
+                if !reversed
+                {
+                    ta.cmp(&tb)
+                } else {
+                    tb.cmp(&ta)
+                }
+            };
+
             walk_sorted = walk_sorted
                 .sort_by_file_path(move |a,b| { compare_accessed(a,b) } );
         }
         else
         {
             // unknown order specified
-            println!("unknown sort order specified");
+            panic!("unknown sort order specified");
         }
 
         for result in walk_sorted.build(){

--- a/src/ig/searcher.rs
+++ b/src/ig/searcher.rs
@@ -3,9 +3,11 @@ use grep::{
     matcher::LineTerminator,
     regex::RegexMatcherBuilder,
     searcher::{BinaryDetection, SearcherBuilder},
+//    flags::lowargs::{SortMode,},
 };
 use ignore::WalkBuilder;
 use std::{path::Path, sync::mpsc};
+use std::{cmp::Ordering};
 
 pub enum Event {
     NewEntry(FileEntry),
@@ -60,9 +62,11 @@ fn run(path: &Path, config: SearchConfig, tx: mpsc::Sender<Event>) {
         .hidden(!config.search_hidden)
         .follow_links(config.follow_links);
 
-    let sorted = true;
-    if !sorted
+
+    // if no sort is specified the faster parallel search is used
+    if config.sort_by.is_none() && config.sort_by_reversed.is_none()
     {
+        println!("parallel");
         let walk_parallel = walker
             .build_parallel();
 
@@ -101,8 +105,62 @@ fn run(path: &Path, config: SearchConfig, tx: mpsc::Sender<Event>) {
     }
     else
     {
-        let walk_sorted = walker
-            .sort_by_file_name(|a,b| a.cmp(b));
+        let mut walk_sorted = walker;
+        let reversed = config.sort_by_reversed.is_some();
+
+        if config.sort_by == Some("path".to_string()) || config.sort_by_reversed == Some("path".to_string())
+        {
+            println!("by name");
+            walk_sorted = walk_sorted
+                .sort_by_file_name(move |a,b| { if !reversed {a.cmp(b)} else {b.cmp(a)}} );
+        }
+        else if config.sort_by == Some("modified".to_string()) || config.sort_by_reversed == Some("modified".to_string())
+        {
+            fn compare_modified (a: &Path, b: &Path) -> Ordering {
+                let ma = a.metadata().expect("cannot get metadata from file");
+                let mb = b.metadata().expect("cannot get metadata from file");
+
+                let ta = ma.modified().expect("cannot get time of file");
+                let tb = mb.modified().expect("cannot get time of file");
+
+                ta.cmp(&tb)
+            }
+            walk_sorted = walk_sorted
+                .sort_by_file_path(move |a,b| { compare_modified(a,b) } );
+        }
+        else if config.sort_by == Some("created".to_string()) || config.sort_by_reversed == Some("created".to_string())
+        {
+            fn compare_created (a: &Path, b: &Path) -> Ordering {
+                let ma = a.metadata().expect("cannot get metadata from file");
+                let mb = b.metadata().expect("cannot get metadata from file");
+
+                let ta = ma.created().expect("cannot get time of file");
+                let tb = mb.created().expect("cannot get time of file");
+
+                ta.cmp(&tb)
+            }
+            walk_sorted = walk_sorted
+                .sort_by_file_path(move |a,b| { compare_created(a,b) } );
+        }
+        else if config.sort_by == Some("accessed".to_string()) || config.sort_by_reversed == Some("accessed".to_string())
+        {
+            fn compare_accessed (a: &Path, b: &Path) -> Ordering {
+                let ma = a.metadata().expect("cannot get metadata from file");
+                let mb = b.metadata().expect("cannot get metadata from file");
+
+                let ta = ma.accessed().expect("cannot get time of file");
+                let tb = mb.accessed().expect("cannot get time of file");
+
+                ta.cmp(&tb)
+            }
+            walk_sorted = walk_sorted
+                .sort_by_file_path(move |a,b| { compare_accessed(a,b) } );
+        }
+        else
+        {
+            // unknown order specified
+            println!("unknown sort order specified");
+        }
 
         for result in walk_sorted.build(){
             let tx = tx.clone();

--- a/src/ig/searcher.rs
+++ b/src/ig/searcher.rs
@@ -66,7 +66,6 @@ fn run(path: &Path, config: SearchConfig, tx: mpsc::Sender<Event>) {
     // if no sort is specified the faster parallel search is used
     if config.sort_by.is_none() && config.sort_by_reversed.is_none()
     {
-        println!("parallel");
         let walk_parallel = walker
             .build_parallel();
 
@@ -110,7 +109,6 @@ fn run(path: &Path, config: SearchConfig, tx: mpsc::Sender<Event>) {
 
         if config.sort_by == Some("path".to_string()) || config.sort_by_reversed == Some("path".to_string())
         {
-            println!("by name");
             walk_sorted = walk_sorted
                 .sort_by_file_name(move |a,b| { if !reversed {a.cmp(b)} else {b.cmp(a)}} );
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,8 @@ fn main() -> Result<()> {
         .follow_links(args.follow_links)
         .word_regexp(args.word_regexp)
         .globs(args.glob)?
-        .file_types(args.type_matching, args.type_not)?;
+        .file_types(args.type_matching, args.type_not)?
+        .sort_by(args.sort_by, args.sort_by_reverse)?;
 
     let theme: Box<dyn Theme> = match args.theme {
         ThemeVariant::Light => Box::new(Light),

--- a/src/ui/input_handler.rs
+++ b/src/ui/input_handler.rs
@@ -480,7 +480,7 @@ mod tests {
 
     #[test_case(&[Char('q')]; "q")]
     #[test_case(&[Esc]; "empty input state")]
-    #[test_case(&[Char('a'), Char('b'), Esc]; "invalid input state")]
+    #[test_case(&[Char('b'), Char('e'), Esc]; "invalid input state")]
     #[test_case(&[Char('d'), Esc, Esc]; "clear incomplete state first")]
     fn exit(key_codes: &[KeyCode]) {
         let mut app_mock = MockApplication::default();

--- a/src/ui/input_handler.rs
+++ b/src/ui/input_handler.rs
@@ -183,6 +183,7 @@ impl InputHandler {
         };
 
         match self.input_buffer.as_str() {
+            // navigation
             "j" => consume_buffer_and_execute(&mut self.input_buffer, &mut || app.on_next_match()),
             "k" => {
                 consume_buffer_and_execute(&mut self.input_buffer, &mut || app.on_previous_match())
@@ -193,12 +194,14 @@ impl InputHandler {
             }
             "gg" => consume_buffer_and_execute(&mut self.input_buffer, &mut || app.on_top()),
             "G" => consume_buffer_and_execute(&mut self.input_buffer, &mut || app.on_bottom()),
+            // deletion
             "dd" => consume_buffer_and_execute(&mut self.input_buffer, &mut || {
                 app.on_remove_current_entry()
             }),
             "dw" => consume_buffer_and_execute(&mut self.input_buffer, &mut || {
                 app.on_remove_current_file()
             }),
+            // viewer
             "v" => consume_buffer_and_execute(&mut self.input_buffer, &mut || {
                 app.on_toggle_context_viewer_vertical()
             }),
@@ -211,6 +214,20 @@ impl InputHandler {
             "-" => consume_buffer_and_execute(&mut self.input_buffer, &mut || {
                 app.on_decrease_context_viewer_size()
             }),
+            // sort
+            "n" => consume_buffer_and_execute(&mut self.input_buffer, &mut || {
+                app.on_toggle_sort_name()
+            }),
+            "m" => consume_buffer_and_execute(&mut self.input_buffer, &mut || {
+                app.on_toggle_sort_mtime()
+            }),
+            "a" => consume_buffer_and_execute(&mut self.input_buffer, &mut || {
+                app.on_toggle_sort_atime()
+            }),
+            "c" => consume_buffer_and_execute(&mut self.input_buffer, &mut || {
+                app.on_toggle_sort_ctime()
+            }),
+            // misc
             "q" => consume_buffer_and_execute(&mut self.input_buffer, &mut || app.on_exit()),
             "?" => {
                 consume_buffer_and_execute(&mut self.input_buffer, &mut || app.on_toggle_keymap())
@@ -219,6 +236,7 @@ impl InputHandler {
                 self.input_mode = InputMode::TextInsertion;
                 consume_buffer_and_execute(&mut self.input_buffer, &mut || app.on_toggle_popup())
             }
+            // buffer for multikey inuts
             "g" => self.input_state = InputState::Incomplete("g…".into()),
             "d" => self.input_state = InputState::Incomplete("d…".into()),
             buf => {

--- a/src/ui/input_handler.rs
+++ b/src/ui/input_handler.rs
@@ -236,7 +236,7 @@ impl InputHandler {
                 self.input_mode = InputMode::TextInsertion;
                 consume_buffer_and_execute(&mut self.input_buffer, &mut || app.on_toggle_popup())
             }
-            // buffer for multikey inuts
+            // buffer for multikey inputs
             "g" => self.input_state = InputState::Incomplete("g…".into()),
             "d" => self.input_state = InputState::Incomplete("d…".into()),
             buf => {


### PR DESCRIPTION
introduces the `--sort` and `--sortr` arguments known by ripgrep to sort by `path, modified, created, accessed`

also wished by https://github.com/konradsz/igrep/issues/61 point 2.

sorting can be changed from the ui. 
* `n` -> by name/path 
* `m` by time modified 
* `c` by time created
* `a`  by time accessed

pressing the key again will reverse the order.


(this is the first time i write in rust, so maybe it could requires some polishing or benefit from different constructs)