### PR TITLE
[ui] display <tab> as 2 <spaces>

### DIFF
--- a/src/ig/file_entry.rs
+++ b/src/ig/file_entry.rs
@@ -14,7 +14,30 @@ impl FileEntry {
                 .chain(
                     matches
                         .into_iter()
-                        .map(|m| EntryType::Match(m.line_number, m.text, m.match_offsets)),
+                        .map(|m| {
+                            let mut text = String::new();
+                            let mut ofs = m.match_offsets;
+                            let mut pos = 0;
+                            for c in m.text.chars()
+                            {
+                                pos += 1;
+                                if c != '\t'
+                                {
+                                    text.push(c);
+                                    continue
+                                }
+                                text.push_str("  ");
+                                for p in &mut ofs
+                                {
+                                    if p.0 >= pos
+                                    {
+                                        p.0 += 1;
+                                        p.1 += 1;
+                                    }
+                                }
+                            }
+                            EntryType::Match(m.line_number, text, ofs)
+                        }),
                 )
                 .collect(),
         )


### PR DESCRIPTION
lines containing tabs (`\t`) breaks the layout. the box is lost and characters remain when the lines move over the screen.

related to: https://github.com/ratatui/ratatui/issues/876

so this MR will replace `\t` with `  ` (two spaces). it also updates the matcher offset so the highlight remains on the searched pattern.