### PR TITLE
feat: add `-U`/`--multiline` option for searching patterns with `\n`.

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -52,6 +52,9 @@ pub struct Args {
     /// Exact matches with no regex. Useful when searching for a string full of delimiters.
     #[clap(short = 'F', long = "fixed-strings")]
     pub fixed_strings: bool,
+    /// Search with pattern contains newline character ('\n').
+    #[clap(short = 'U', long = "multiline")]
+    pub multi_line: bool,
     /// Include files and directories for searching that match the given glob.
     /// Multiple globs may be provided.
     #[clap(short, long)]

--- a/src/ig/search_config.rs
+++ b/src/ig/search_config.rs
@@ -32,6 +32,7 @@ pub struct SearchConfig {
     pub word_regexp: bool,
     pub sort_by: Option<SortKey>,
     pub fixed_strings: bool,
+    pub multi_line: bool,
 }
 
 impl SearchConfig {
@@ -51,6 +52,7 @@ impl SearchConfig {
             follow_links: false,
             word_regexp: false,
             fixed_strings: false,
+            multi_line: false,
             sort_by: None,
         })
     }
@@ -132,6 +134,11 @@ impl SearchConfig {
 
     pub fn fixed_strings(mut self, fixed_strings: bool) -> Self {
         self.fixed_strings = fixed_strings;
+        self
+    }
+
+    pub fn multi_line(mut self, multi_line: bool) -> Self {
+        self.multi_line = multi_line;
         self
     }
 }

--- a/src/ig/searcher.rs
+++ b/src/ig/searcher.rs
@@ -44,15 +44,22 @@ fn run(path: &Path, config: SearchConfig, tx: mpsc::Sender<Event>) {
         .binary_detection(BinaryDetection::quit(b'\x00'))
         .line_terminator(LineTerminator::byte(b'\n'))
         .line_number(true)
-        .multi_line(false)
+        .multi_line(config.multi_line)
         .build();
 
-    let matcher = RegexMatcherBuilder::new()
-        .line_terminator(Some(b'\n'))
+    let mut regex_matcher_builder = RegexMatcherBuilder::new();
+    regex_matcher_builder
         .case_insensitive(config.case_insensitive)
         .case_smart(config.case_smart)
         .word(config.word_regexp)
         .fixed_strings(config.fixed_strings)
+        .multi_line(config.multi_line);
+
+    // HACK: without this we will occur the NotAllowed("\n").
+    if !config.multi_line {
+        regex_matcher_builder.line_terminator(Some(b'\n'));
+    }
+    let matcher = regex_matcher_builder
         .build(&config.pattern)
         .expect("Cannot build RegexMatcher");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,7 @@ fn main() -> Result<()> {
         .follow_links(args.follow_links)
         .word_regexp(args.word_regexp)
         .fixed_strings(args.fixed_strings)
+        .multi_line(args.multi_line)
         .globs(args.glob)?
         .file_types(args.type_matching, args.type_not)?
         .sort_by(args.sort_by, args.sort_by_reverse)?;


### PR DESCRIPTION
Resolve #84.